### PR TITLE
fix(docs): Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `gitcommit` grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
-Support [Conventionnal commit](https://www.conventionalcommits.org) specifications.
+Support for [Conventional Commits](https://www.conventionalcommits.org) specifications.
 
 ## Credits
 


### PR DESCRIPTION
Conventionnal -> Conventional

Slightly re-words the sentence as well.