### PR TITLE
chore: add check for generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   pull_request:
     branches:
@@ -6,17 +7,37 @@ on:
   push:
     branches:
       - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    name: Run validation tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install
-      - run: npm test
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tree-sitter tests
+        run: npm test
+
+      - name: Ensure generated parser files are up-to-date
+        # On Windows, tree-sitter generate results in a diff, not sure why
+        if: runner.os != 'Windows'
+        run: |
+          git status
+          test -z "$(git status --porcelain)"


### PR DESCRIPTION
resolves #16 .

And also added a concurrency check, so each workflow + ref group only runs one concurrent CI job. https://docs.github.com/en/actions/using-jobs/using-concurrency#overview

**Note:**
* had to turn off the check for Windows because on Windows, it seems that treesitter was generating different files from macos/linux. https://github.com/thatlittleboy/tree-sitter-gitcommit/actions/runs/3823834159/jobs/6505421553

![image](https://user-images.githubusercontent.com/30731072/210261720-86497181-fc7b-4b6d-96ce-e622fff6bb5d.png)
