### PR TITLE
feat: make tree-sitter-cli work

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,12 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.7"
-  }
+  },
+  "tree-sitter": [
+    {
+      "file-types": [
+        "COMMIT_EDITMSG"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Add file type "COMMIT_EDITMSG" to package.json to make the parser work with tree-sitter-cli.

Otherwise the package is not recognized (e.g. of `tree-sitter highlight`).